### PR TITLE
Always call getPresharedKey before verifyKey

### DIFF
--- a/volumes/source/Simulator.py
+++ b/volumes/source/Simulator.py
@@ -393,12 +393,11 @@ class Simulator(QKD):
 				raise(e)
 
 			if authenticationMethod == 'aesgcm':
-				if TTL == 0:
-					# we need to take another key
-					key, keyID, TTL = getPresharedKey()
-					if key is None:
-						# no key available, return an error
-						return None, False, 0
+				# we need to take another key
+				key, keyID, TTL = getPresharedKey()
+				if key is None:
+					# no key available, return an error
+					return None, False, 0
 				aesgcm = AESGCM(bytes(key, 'utf-8'))
 				# select nonce
 				nonceVK = randomStringGen(12)


### PR DESCRIPTION
Hi Ignazio,

When I am using your QKD simulator for some benchmark with AES-GCM, I found that Bob will return "No preshared key found" error after 10 key exchanges. This is because the TTL for the same key will be reduced by 1 on Alice while reduced by 2 on Bob (compareBasis and verifyKey) per key exchange. This will get a key removed from Bob's database when TTL=10 for the same key on Alice.

Fix by always calling getPresharedKey before posting the verifyKey request.